### PR TITLE
Add MockSprawl skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Cargo build outputs
 **/target/
 **/.idea/
+node_modules/

--- a/mock/crawled_server/README.md
+++ b/mock/crawled_server/README.md
@@ -1,0 +1,12 @@
+# MockSprawl - Mock Servers for Crawler Resistance Training
+
+This directory contains a collection of hostile mock websites built with Next.js. Each sub-route simulates a different crawling challenge such as client-side rendering, deceptive sitemaps and user agent blocking.
+
+Run the server locally:
+
+```bash
+npm install
+npm run dev
+```
+
+See each folder under `app/` for details of the individual mock sites.

--- a/mock/crawled_server/app/anti-bot/page.tsx
+++ b/mock/crawled_server/app/anti-bot/page.tsx
@@ -1,0 +1,10 @@
+export const dynamic = 'force-dynamic';
+
+export default function AntiBot() {
+  return (
+    <div>
+      <h1>BotWarden</h1>
+      <p>Your user agent is being checked by middleware.</p>
+    </div>
+  );
+}

--- a/mock/crawled_server/app/client-only/page.tsx
+++ b/mock/crawled_server/app/client-only/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function ClientOnly() {
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    setReady(true);
+  }, []);
+  if (!ready) return null;
+  return (
+    <div>
+      <h1>ClientShadow</h1>
+      <p>This content only appears after client-side rendering.</p>
+    </div>
+  );
+}

--- a/mock/crawled_server/app/dynamic/page.tsx
+++ b/mock/crawled_server/app/dynamic/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+export default function DynamicPage() {
+  const random = Math.random().toString(36).substring(2, 8);
+  return (
+    <div>
+      <h1>DynamicMaze</h1>
+      <p>Random content id: {random}</p>
+    </div>
+  );
+}

--- a/mock/crawled_server/app/layout.tsx
+++ b/mock/crawled_server/app/layout.tsx
@@ -1,0 +1,10 @@
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <title>MockSprawl</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/mock/crawled_server/app/map/page.tsx
+++ b/mock/crawled_server/app/map/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function MapPage() {
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.src = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js';
+    script.onload = () => {
+      const L = (window as any).L;
+      const map = L.map('map').setView([35.0, 135.0], 4);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
+    };
+    document.body.appendChild(script);
+  }, []);
+
+  return (
+    <div>
+      <h1>MapTown</h1>
+      <div id="map" style={{ height: '400px' }}></div>
+    </div>
+  );
+}

--- a/mock/crawled_server/app/meta-fake/page.tsx
+++ b/mock/crawled_server/app/meta-fake/page.tsx
@@ -1,0 +1,13 @@
+export const metadata = {
+  title: 'Totally Not About Cats',
+  description: 'A blog about gardening.'
+};
+
+export default function MetaFake() {
+  return (
+    <div>
+      <h1>Actual Content: Dogs!</h1>
+      <p>The meta tags lie about the content.</p>
+    </div>
+  );
+}

--- a/mock/crawled_server/app/no-sitemap/page.tsx
+++ b/mock/crawled_server/app/no-sitemap/page.tsx
@@ -1,0 +1,8 @@
+export default function NoMapZone() {
+  return (
+    <div>
+      <h1>NoMapZone</h1>
+      <p>This site intentionally lacks a sitemap.</p>
+    </div>
+  );
+}

--- a/mock/crawled_server/app/partial-map/page.tsx
+++ b/mock/crawled_server/app/partial-map/page.tsx
@@ -1,0 +1,8 @@
+export default function PartialMap() {
+  return (
+    <div>
+      <h1>HalfMapSite</h1>
+      <p>Only some pages are listed in the sitemap.</p>
+    </div>
+  );
+}

--- a/mock/crawled_server/app/static/page.tsx
+++ b/mock/crawled_server/app/static/page.tsx
@@ -1,0 +1,10 @@
+export const dynamic = 'error'; // Disable SSR caching
+
+export default function StaticPage() {
+  return (
+    <div>
+      <h1>Welcome to StaticLand</h1>
+      <p>This page is completely static and easy for crawlers.</p>
+    </div>
+  );
+}

--- a/mock/crawled_server/app/trap-broken/page.tsx
+++ b/mock/crawled_server/app/trap-broken/page.tsx
@@ -1,0 +1,9 @@
+export default function BrokenWeb() {
+  return (
+    <div>
+      <h1>BrokenWeb</h1>
+      <p>This page references links that do not exist.</p>
+      <a href="/trap-broken/missing">Broken link</a>
+    </div>
+  );
+}

--- a/mock/crawled_server/app/trap/[slug]/page.tsx
+++ b/mock/crawled_server/app/trap/[slug]/page.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+interface Props {
+  params: { slug: string[] };
+}
+
+export default function TrapPage({ params }: Props) {
+  const nextSlug = [...(params.slug || []), Math.random().toString(36).substring(2, 4)].join('/');
+  return (
+    <div>
+      <h1>LinkSpiral</h1>
+      <p>You are in a trap page: {params.slug?.join('/')}</p>
+      <Link href={`/trap/${nextSlug}`}>Next trap</Link>
+    </div>
+  );
+}

--- a/mock/crawled_server/middleware.ts
+++ b/mock/crawled_server/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const ua = request.headers.get('user-agent') || '';
+  if (/bot|crawler|spider/i.test(ua)) {
+    return new NextResponse('Blocked', { status: 403 });
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/anti-bot/:path*'],
+};

--- a/mock/crawled_server/next-env.d.ts
+++ b/mock/crawled_server/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/mock/crawled_server/next.config.js
+++ b/mock/crawled_server/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/mock/crawled_server/public/robots.txt
+++ b/mock/crawled_server/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /anti-bot

--- a/mock/crawled_server/public/sitemap.xml
+++ b/mock/crawled_server/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>/static</loc></url>
+  <url><loc>/client-only</loc></url>
+  <url><loc>/partial-map</loc></url>
+</urlset>

--- a/mock/crawled_server/tsconfig.json
+++ b/mock/crawled_server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "noEmit": true,
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- create `mock/crawled_server` with Next.js skeleton
- add pages for various crawler traps
- include middleware, config, and public files
- update `.gitignore` for Node projects

## Testing
- `go test ./store_go`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684d4e75c8e083299ec05f384dd5c740