### PR TITLE
Add StaticLand mock site

### DIFF
--- a/mock/crawled_server/app/static/about/page.tsx
+++ b/mock/crawled_server/app/static/about/page.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "About - StaticLand",
+};
+
+export default function AboutPage() {
+  return (
+    <main>
+      <h1>About StaticLand</h1>
+      <p>This page provides some static information about the site.</p>
+      <p><Link href="/static">Back to Home</Link></p>
+    </main>
+  );
+}

--- a/mock/crawled_server/app/static/contact/page.tsx
+++ b/mock/crawled_server/app/static/contact/page.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "Contact - StaticLand",
+};
+
+export default function ContactPage() {
+  return (
+    <main>
+      <h1>Contact Us</h1>
+      <p>You can reach us by sending a message via carrier pigeon.</p>
+      <p><Link href="/static">Back to Home</Link></p>
+    </main>
+  );
+}

--- a/mock/crawled_server/app/static/page.tsx
+++ b/mock/crawled_server/app/static/page.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "StaticLand",
+  description: "A fully static sample site with simple HTML pages.",
+};
+
+export default function StaticLandHome() {
+  return (
+    <main>
+      <h1>Welcome to StaticLand</h1>
+      <p>This is a simple static site used for crawler testing.</p>
+      <ul>
+        <li><Link href="/static/about">About</Link></li>
+        <li><Link href="/static/contact">Contact</Link></li>
+      </ul>
+    </main>
+  );
+}

--- a/mock/crawled_server/public/robots.txt
+++ b/mock/crawled_server/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow:
+Sitemap: /sitemap.xml

--- a/mock/crawled_server/public/sitemap.xml
+++ b/mock/crawled_server/public/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>http://localhost:3000/static</loc>
+  </url>
+  <url>
+    <loc>http://localhost:3000/static/about</loc>
+  </url>
+  <url>
+    <loc>http://localhost:3000/static/contact</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- create StaticLand pages with simple HTML links
- add sitemap.xml and robots.txt for StaticLand

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684d666676dc83298cd2d1e16c330728